### PR TITLE
add FreeBSD

### DIFF
--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,4 +1,3 @@
 ---
-pkg_upgrade_privilege_escalation: False
 pkg_upgrade_update_cmd: pkg update
 pkg_upgrade_upgrade_cmd: pkg upgrade --no-repo-update -y

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,0 +1,4 @@
+---
+pkg_upgrade_privilege_escalation: False
+pkg_upgrade_update_cmd: pkg update
+pkg_upgrade_upgrade_cmd: pkg upgrade --no-repo-update -y


### PR DESCRIPTION
Tested against a local jail running on FreeNAS.
```
"ansible_distribution": "FreeBSD", 
"ansible_distribution_release": "11.1-STABLE", 
"ansible_distribution_version": "FreeBSD 11.1-STABLE #0 r321665+d4625dcee3e(freenas/11.1-stable): Wed Dec 13 16:33:42 UTC 2017     root@gauntlet:/freenas-11-releng/freenas/_BE/objs/freenas-11-releng/freenas/_BE/os/sys/FreeNAS.amd64", 
```

You could also have simply …
```
---
pkg_upgrade_upgrade_cmd: pkg upgrade -y
```
… but keeping the actions separate might help diagnose failure (although I'm not sure whether a failed `update...` would be detected and cause the rest of the role to abort).

_(These two commits can be squashed; the first one is unnecessary)_